### PR TITLE
Automatically retrieve the last release tag from Git::Tag

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
+++ b/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
@@ -25,6 +25,11 @@ If given, the line is added to the specified group.
 
 The master developing branch. Defaults to I<master>.
 
+=head2 auto_previous_tag
+
+If enabled, look in the guts of the L<Dist::Zilla::Plugin::Git::Tag> plugin in order to find the
+previous release's tag. This will be then compared against the develop_branch. Defaults to false (0).
+
 =head2 release_branch
 
 The branch recording the releases. Defaults to I<releases>.
@@ -73,6 +78,12 @@ has "release_branch" => (
     default => 'releases'
 );
 
+has "auto_previous_tag" => (
+    isa => 'Bool',
+    is => 'ro',
+    default => 0,
+);
+
 has group => (
     is => 'ro',
     default => '',
@@ -83,9 +94,15 @@ has stats => (
     lazy => 1,
     default => sub {
         my $self = shift;
-        
+
+	# What are we diffing against? :)
+	my( $prev, $next ) = ( $self->release_branch, $self->develop_branch );
+	if ( $self->auto_previous_tag ) {
+		$prev = $self->_get_previous_tag;
+	}
+	$self->log_debug( "Comparing '$prev' against '$next' for code stats" );
         my @output = $self->repo->run( 'diff', '--stat',
-            join '...', $self->release_branch, $self->develop_branch
+            join '...', $prev, $next
         );
 
         # actually, only the last line is interesting
@@ -95,6 +112,17 @@ has stats => (
         return $stats;
   } 
 );
+
+sub _get_previous_tag {
+	my( $self ) = @_;
+	my @plugins = grep { $_->isa('Dist::Zilla::Plugin::Git::Tag') } @{ $self->zilla->plugins_with( '-Git::Repo' ) };
+	die "We dont know what to do with multiple Git::Tag plugins loaded!" if scalar @plugins > 1;
+	die "Please load the Git::Tag plugin to use auto_release_tag or disable it!" if ! scalar @plugins;
+	(my $match = $plugins[0]->tag_format) =~ s/\%\w/\.\+/g; # hack.
+	$match = ( grep { $_ =~ /$match/ } $self->repo->run( 'tag' ) )[-1];
+	die "Unable to find the previous tag!" if ! defined $match;
+	return $match;
+}
 
 sub munge_files {
   my ($self) = @_;


### PR DESCRIPTION
Basically this cribs the tag_regexp idea from Git::Tag and makes it possible for both modules to be used in a sane fashion :)

Two new attr's added: release_regexp and develop_regexp that enables the tag-searching functionality.

Thanks for looking into this!