### PR TITLE
- Fix regex warnings (and tests) in recent perls

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
+++ b/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
@@ -114,7 +114,7 @@ sub after_release {
 
   my $changes = CPAN::Changes->load( 
       $self->zilla->changelog_name,
-      next_token => qr/{{\$NEXT}}/ 
+      next_token => qr/\{\{\$NEXT\}\}/
   ); 
 
   for my $next ( reverse $changes->releases ) {

--- a/lib/Dist/Zilla/Role/Author/YANICK/Changelog.pm
+++ b/lib/Dist/Zilla/Role/Author/YANICK/Changelog.pm
@@ -46,7 +46,7 @@ sub changelog {
 
     return CPAN::Changes->load_string( 
         $self->changelog_file->content, 
-        next_token => qr/{{\$NEXT}}/
+        next_token => qr/\{\{\$NEXT\}\}/
     );
 }
 


### PR DESCRIPTION
The "{" and "}" were unescaped which caused perl to warn and the tests
to fail.