### PR TITLE
Text and file skip

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
+++ b/lib/Dist/Zilla/Plugin/ChangeStats/Git.pm
@@ -35,6 +35,20 @@ previous release's tag. This will be then compared against the develop_branch. D
 
 The branch recording the releases. Defaults to I<releases>.
 
+=head2 text
+
+The text before git output. If it is a non-empty string, C<:E<lt>spaceE<gt>> will be appended. Defaults to I<code churn>.
+
+=head2 skip_file
+
+A complete path (from the distribution root) that should not be included in the statistics. Can be given
+multiple times.
+
+=head2 skip_match
+
+A part of a regex used to match against complete paths. Paths that match are not included in the statistics. Can be
+given multiple times.
+
 =cut
 
 use strict;
@@ -217,10 +231,10 @@ sub munge_files {
 sub after_release {
   my $self = shift;
   return unless $self->stats;
-  my $changes = CPAN::Changes->load( 
+  my $changes = CPAN::Changes->load(
       $self->zilla->changelog_name,
       next_token => qr/\{\{\$NEXT\}\}/
-  ); 
+  );
 
   for my $next ( reverse $changes->releases ) {
     next if $next->version =~ /NEXT/;

--- a/lib/Dist/Zilla/Role/Author/YANICK/RequireZillaRole.pm
+++ b/lib/Dist/Zilla/Role/Author/YANICK/RequireZillaRole.pm
@@ -25,8 +25,9 @@ role {
         $zilla->meta->make_mutable;
 
         for my $role ( @{ $p->roles } ) {
+
             $role =~ s/^\+// 
-                or $role =~ s/^/Dist::Zilla::Role::/;
+                or $role =~ s/^/Dist::Zilla::Role::/ if $role !~ m/^Dist::Zilla::Role::/;
 
             next if $zilla->does($role);
 


### PR DESCRIPTION
Hi,

This adds three attributes:

* `text` Customizable leading text instead of hardcoded as 'code churn'.
* `skip_file` Files to be skipped.
* `skip_match` Files are matched against this regex and skipped if matching.

The two `skip_*` attributes are useful if (for example) one doesn't want to include generated files in the calculations. Both of these are arrays.

I changed `git diff --stat` to `git diff --shortstat` for the normal case. It only outputs the summary information.

If any of the `skip_*` attributes are used, it instead uses `--numstat`, parses the result manually and generates a summary identically formatted as that generated by git.

I added a copule of tests. The change in `::RequireZillaRole` was necessary for testing, otherwise `Dist::Zilla::Role::` was prepended to the role multiple times.